### PR TITLE
Call newTransaction() on synchronizers for transaction.get()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.4.4 (unreleased)
 ------------------
 
+- Call newTransaction() on synchronizers when a new transaction is started
+  implicitly by a call to transaction.get().
+
 - Add support for PyPy3.
 
 - Require 100% branch coverage (in addition to 100% statement coverage).

--- a/transaction/_manager.py
+++ b/transaction/_manager.py
@@ -76,9 +76,9 @@ class TransactionManager(object):
     def get(self):
         """ See ITransactionManager.
         """
-        if self._txn is None:
-            self._txn = Transaction(self._synchs, self)
-        return self._txn
+        if self._txn is not None:
+            return self._txn
+        return self.begin()
 
     def free(self, txn):
         if txn is not self._txn:


### PR DESCRIPTION
Closes https://bugs.launchpad.net/zodb/+bug/1153116.
> For a synchronizer, the newTransaction() method is only called when an explicit call to transaction.begin() is made, and not when a new transaction is implicitly started by a call to transaction.get(). These two cases (explicitly vs implicitly begun transactions) should be treated the same, and newTransaction() should be called in both cases.
>
> Some comments from Jim Fulton on zodb-dev on resolution:
>> Really, ``begin`` and ``abort`` are equivalent. It might be better if there wasn't a ``begin`` method, as it's missleading. One should be an alias for the other. I'd be for deprecating ``begin``. The call to ``_new_transaction`` should be moved to the point in ``get`` where a new transaction is created, and ``begin`` should be made an alias for ``abort``.

This PR differs so that ``transaction.begin()`` still returns the new transaction.