### PR TITLE
Drop support for Python 2.6 and 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-    - 2.6
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     - pypy
@@ -11,6 +9,6 @@ python:
 install:
     - pip install .
 script:
-    - python setup.py test -q
+    - python setup.py -q test -q
 notifications:
     email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changes
 =======
 
-1.4.5 (unreleased)
+1.5.0 (unreleased)
 ------------------
 
-- TBD
+- Drop support for Python 2.6 and 3.2.
 
 1.4.4 (2015-05-19)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def _read_file(filename):
 README = _read_file('README.rst') + '\n\n' + _read_file('CHANGES.rst')
 
 setup(name='transaction',
-      version='1.4.5.dev0',
+      version='1.5.0.dev0',
       description='Transaction management for Python',
       long_description=README,
       classifiers=[
@@ -40,10 +40,8 @@ setup(name='transaction',
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,15 @@
 # Jython 2.7rc2+ does work, but unfortunately has an issue running
 # with Tox 1.9.2 (see https://github.com/pypa/virtualenv/pull/746)
 envlist =
-    py26,py27,pypy,py32,py33,py34,pypy3,coverage,docs
+    py27,pypy,py33,py34,pypy3,coverage,docs
 
 [testenv]
 commands =
-    python setup.py test -q
-deps = transaction
+    python setup.py -q test -q
 
 [testenv:coverage]
 basepython =
-    python2.6
+    python2.7
 commands =
     nosetests --with-xunit --with-xcoverage
 deps =
@@ -21,7 +20,7 @@ deps =
 
 [testenv:docs]
 basepython =
-    python2.6
+    python2.7
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest


### PR DESCRIPTION
- 2.6 is long out-of-maintenance, and a security quagmire.

- 3.2 cannot be tested on Travis.