### PR TITLE
Free DataManagers when a transaction becomes non-current.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+1.6.0 (TBD)
+-----------
+
+- Drop references to data managers joined to a transaction when it is
+  committed or aborted.
+
 1.5.0 (2016-05-05)
 ------------------
 

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -360,7 +360,7 @@ can be executed. We don't support execution dependencies at this level.
 
     >>> reset_log()
 
-Test that the associated transaction manager has been cleanup when
+Test that the associated transaction manager has been cleaned up when
 after commit hooks are registered
 
 .. doctest::


### PR DESCRIPTION
Per [the discussion on the mailing list](https://groups.google.com/forum/#!topic/python-transaction/oUzj3uIHBgA)

This is the bare implementation of that, only freeing resources when _manager.free() is called. A few notes:

- We could also free the manager instance. This breaks a test in hooks.rst though.
- The free method is not being called in a finally block. In the case of abort() this is probably acceptable because each individual data manager is protected by a try/except. Presumably in the case of a failed commit(), though, we are expecting people to turn around and call abort()? So in practice this should all work out?
- Possible behaviour change: the synchronizers' `afterCompletion` methods are now being called with `_resources` empty (the manager would already have been cleared prior to this change). Since `_resources` is a private ivar, we shouldn't have to be concerned about this?