### PR TITLE
Restore display of missing lines.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 exclude_lines =
     # pragma: no cover
     class I[A-Z]\w+\((Interface|I[A-Z].*)\):
+show_missing = true


### PR DESCRIPTION
Coverage 4.1 defaults 'show_missing' to False.

See http://stackoverflow.com/questions/37733194/python-nosetests-with-coverage-no-longer-shows-missing-lines/37746141#37746141