### PR TITLE
Make sure that the attempts generator stops after first successful attempt

### DIFF
--- a/docs/convenience.rst
+++ b/docs/convenience.rst
@@ -125,6 +125,8 @@ Of course, other errors are propagated directly:
     >>> for attempt in transaction.manager.attempts():
     ...     with attempt:
     ...         ntry += 1
+    ...         if ntry % 3:
+    ...             raise Retry(ntry)
     ...         if ntry == 3:
     ...             raise ValueError(ntry)
     Traceback (most recent call last):

--- a/transaction/_manager.py
+++ b/transaction/_manager.py
@@ -144,7 +144,10 @@ class TransactionManager(object):
         while number:
             number -= 1
             if number:
-                yield Attempt(self)
+                attempt = Attempt(self)
+                yield attempt
+                if attempt.success:
+                    break
             else:
                 yield self
 
@@ -167,6 +170,8 @@ class ThreadTransactionManager(TransactionManager, threading.local):
 
 class Attempt(object):
 
+    success = False
+
     def __init__(self, manager):
         self.manager = manager
 
@@ -184,6 +189,7 @@ class Attempt(object):
         if v is None:
             try:
                 self.manager.commit()
+                self.success = True
             except:
                 return self._retry_or_raise(*sys.exc_info())
         else:

--- a/transaction/tests/test__manager.py
+++ b/transaction/tests/test__manager.py
@@ -246,6 +246,12 @@ class TransactionManagerTests(unittest.TestCase):
             self.assertTrue(attempt.manager is tm)
         self.assertTrue(found[-1] is tm)
 
+    def test_attempts_succes_breaks(self):
+        tm = self._makeOne()
+        for runs, attempt in enumerate(tm.attempts()):
+            attempt.success = True
+        self.assertEqual(runs, 0)
+
     def test__retryable_w_transient_error(self):
         from transaction.interfaces import TransientError
         tm = self._makeOne()


### PR DESCRIPTION
As described in issue #19  the current behavior is not as explained in the docs. This pull request changes the code to break if an attempt was successful.
