### PR TITLE
Run decorator, a simpler alternative to attempts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changes
 =======
 
-Unreleased
-----------
+- Added a transaction-manager ``run`` for running a function as a
+  transaction, retrying as necessary on transient errors.
 
 - Fixed the transaction manager ``attempts`` method. It didn't stop
   repeating when there wasn't an error.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,10 @@ Interfaces
    :members:
    :member-order: bysource
 
+.. autointerface:: IRetryDataManager
+   :members:
+   :member-order: bysource
+
 .. autointerface:: IDataManagerSavepoint
    :members:
    :member-order: bysource

--- a/docs/convenience.rst
+++ b/docs/convenience.rst
@@ -76,19 +76,18 @@ The first helper runs a function as a transaction::
 
     transaction.manager.run(do_somthing)
 
-Of course you can run this as a decorator::
+You can also use this as a decorator, which executes the decorated
+function immediately [#decorator-executes]_::
 
     @transaction.manager.run
     def _():
         "Do something"
         ... some something ...
 
-Some people find this easier to read, even though the result isn't a
-decorated function, but rather the result of calling it in a
-transaction.  The function name, ``_`` is used here to emphasize that
-the fuction is essentially being used as an anonymous function.
-
-The run method returns the successful result of calling the function.
+The transaction manager ``run`` method will run the function and
+return the results. If the function raises a ``TransientError``, the
+function will be retried a configurable number of times, 3 by
+default. Any other exceptions will be raised.
 
 The function name (if it isn't ``'_'``) and docstring, if any, are
 added to the transaction description.
@@ -103,7 +102,6 @@ You can pass an integer number of times to try to the ``run`` method::
         ... some something ...
 
 The default number of times to try is 3.
-
 
 Retrying code blocks using a attempt iterator
 _____________________________________________
@@ -122,3 +120,9 @@ times, but you can pass a number of attempts::
   for attempt in transaction.manager.attempts(9):
       with attempt as t:
           ... some something ...
+
+.. [#decorator-executes] Some people find this easier to read, even
+   though the result isn't a decorated function, but rather the result of
+   calling it in a transaction.  The function name ``_`` is used here to
+   emphasize that the function is essentially being used as an anonymous
+   function.

--- a/docs/convenience.rst
+++ b/docs/convenience.rst
@@ -79,25 +79,26 @@ The first helper runs a function as a transaction::
 Of course you can run this as a decorator::
 
     @transaction.manager.run
-    def do_somthing():
+    def _():
         "Do something"
         ... some something ...
 
 Some people find this easier to read, even though the result isn't a
 decorated function, but rather the result of calling it in a
-transaction.
+transaction.  The function name, ``_`` is used here to emphasize that
+the fuction is essentially being used as an anonymous function.
 
 The run method returns the successful result of calling the function.
 
-The function name and docstring, if any, are added to the transaction
-description.
+The function name (if it isn't ``'_'``) and docstring, if any, are
+added to the transaction description.
 
 You can pass an integer number of times to try to the ``run`` method::
 
     transaction.manager.run(do_somthing, 9)
 
     @transaction.manager.run(9)
-    def do_somthing():
+    def _():
         "Do something"
         ... some something ...
 

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -428,6 +428,17 @@ class ISavepointDataManager(IDataManager):
         """Return a data-manager savepoint (IDataManagerSavepoint).
         """
 
+class IRetryDataManager(IDataManager):
+
+    def should_retry(exception):
+        """Return whether a given exception instance should be retried.
+
+        A data manager can provide this method to indicate that a a
+        transaction that raised the given error should be retried.
+        This method may be called by an ITransactionManager when
+        considering whether to retry a failed transaction.
+        """
+
 class IDataManagerSavepoint(Interface):
     """Savepoint for data-manager changes for use in transaction savepoints.
 

--- a/transaction/tests/test__manager.py
+++ b/transaction/tests/test__manager.py
@@ -199,7 +199,7 @@ class TransactionManagerTests(unittest.TestCase):
             with tm:
                 tm._txn = txn = _Test()
                 1/0
-        except ZeroDivisionError: 
+        except ZeroDivisionError:
             pass
         self.assertFalse(txn._committed)
         self.assertTrue(txn._aborted)
@@ -245,6 +245,69 @@ class TransactionManagerTests(unittest.TestCase):
                 i += 1
 
         self.assertEqual(i, 1)
+
+    def test_attempts_retries(self):
+        import transaction.interfaces
+        class Retry(transaction.interfaces.TransientError):
+            pass
+
+        tm = self._makeOne()
+        i = 0
+        for attempt in tm.attempts(4):
+            with attempt:
+                i += 1
+                if i < 4:
+                    raise Retry
+
+        self.assertEqual(i, 4)
+
+    def test_attempts_retries_but_gives_up(self):
+        import transaction.interfaces
+        class Retry(transaction.interfaces.TransientError):
+            pass
+
+        tm = self._makeOne()
+        i = 0
+
+        with self.assertRaises(Retry):
+            for attempt in tm.attempts(4):
+                with attempt:
+                    i += 1
+                    raise Retry
+
+        self.assertEqual(i, 4)
+
+    def test_attempts_propigates_errors(self):
+        tm = self._makeOne()
+        with self.assertRaises(ValueError):
+            for attempt in tm.attempts(4):
+                with attempt:
+                    raise ValueError
+
+    def test_attempts_defer_to_dm(self):
+        import transaction.tests.savepointsample
+
+        class DM(transaction.tests.savepointsample.SampleSavepointDataManager):
+            def should_retry(self, e):
+                if 'should retry' in str(e):
+                    return True
+
+        ntry = 0
+        dm = transaction.tests.savepointsample.SampleSavepointDataManager()
+        dm2 = DM()
+        with transaction.manager:
+            dm2['ntry'] = 0
+
+        for attempt in transaction.manager.attempts():
+            with attempt:
+                ntry += 1
+                dm['ntry'] = ntry
+                dm2['ntry'] = ntry
+                if ntry % 3:
+                    raise ValueError('we really should retry this')
+
+        self.assertEqual(ntry, 3)
+
 
     def test_attempts_w_default_count(self):
         from transaction._manager import Attempt
@@ -501,13 +564,13 @@ class AttemptTests(unittest.TestCase):
         self.assertTrue(manager.aborted)
 
     def test___exit__no_exc_abort_exception_after_nonretryable_commit_exc(self):
-        manager = DummyManager(raise_on_abort=ValueError, 
+        manager = DummyManager(raise_on_abort=ValueError,
                                raise_on_commit=KeyError)
         inst = self._makeOne(manager)
         self.assertRaises(ValueError, inst.__exit__, None, None, None)
         self.assertTrue(manager.committed)
         self.assertTrue(manager.aborted)
-        
+
     def test___exit__no_exc_retryable_commit_exception(self):
         from transaction.interfaces import TransientError
         manager = DummyManager(raise_on_commit=TransientError)
@@ -532,13 +595,13 @@ class AttemptTests(unittest.TestCase):
         self.assertRaises(KeyError, inst.__exit__, KeyError, KeyError(), None)
         self.assertFalse(manager.committed)
         self.assertTrue(manager.aborted)
-        
+
 
 class DummyManager(object):
     entered = False
     committed = False
     aborted = False
-    
+
     def __init__(self, raise_on_commit=None, raise_on_abort=None):
         self.raise_on_commit = raise_on_commit
         self.raise_on_abort = raise_on_abort
@@ -546,7 +609,7 @@ class DummyManager(object):
     def _retryable(self, t, v):
         from transaction._manager import TransientError
         return issubclass(t, TransientError)
-        
+
     def __enter__(self):
         self.entered = True
 
@@ -554,7 +617,7 @@ class DummyManager(object):
         self.aborted = True
         if self.raise_on_abort:
             raise self.raise_on_abort
-        
+
     def commit(self):
         self.committed = True
         if self.raise_on_commit:


### PR DESCRIPTION
This implements: https://groups.google.com/forum/#!topic/python-transaction/3eUzBzX2sRU

In addition, this moves the attempts doctest in the docs to a regular tests.  While I like doctests, I don't like to clutter documentation with tests.   The attempts method was bad enough without weird examples muddying the documentation.