### PR TITLE
URGENT: _extension needs to be settable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Changes
 =======
 
+- Fixed: Some legacy applications expect the transaction _extension
+  attribute to be settable and it wasn't.
+
 2.0.1 (2016-11-11)
 ------------------
 

--- a/transaction/_transaction.py
+++ b/transaction/_transaction.py
@@ -124,6 +124,10 @@ class Transaction(object):
         # absent any formal API.
         return self.extended_info
 
+    @_extension.setter
+    def _extension(self, v):
+        self.extended_info = v
+
     @property
     def user(self):
         return self._user

--- a/transaction/tests/test__transaction.py
+++ b/transaction/tests/test__transaction.py
@@ -1024,6 +1024,13 @@ class TransactionTests(unittest.TestCase):
         self.assertEqual(txn._extension, {u'frob': 'quxxxx', u'baz': 'spam'})
         self.assertTrue(txn._extension is txn._extension) # legacy
 
+    def test__extension_settable(self):
+        # Because ZEO sets it. I'll fix ZEO, but maybe something else will break
+        txn = self._makeOne()
+        txn._extension = dict(baz='spam')
+        txn.setExtendedInfo('frob', 'qux')
+        self.assertEqual(txn.extended_info, {u'frob': 'qux', 'baz': 'spam'})
+
     def test_data(self):
         txn = self._makeOne()
 


### PR DESCRIPTION
Fixed: Some legacy applications expect the transaction _extension
  attribute to be settable and it wasn't.

Existing ZEO builds will be broken without this fix.