### PR TITLE
Hate bytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+2.0.3 (unreleased)
+------------------
+
+- The user and description fields must now be set with tex (unicode)
+  data.  Previously, if bytes were provided, they'd be encoded as
+  ASCII.  It was decided that this would lead to bugs that were hard
+  to test for.
+
 2.0.2 (2016-11-13)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changes
 2.0.3 (unreleased)
 ------------------
 
-- The user and description fields must now be set with tex (unicode)
-  data.  Previously, if bytes were provided, they'd be encoded as
+- The user and description fields must now be set with text (unicode)
+  data.  Previously, if bytes were provided, they'd be decoded as
   ASCII.  It was decided that this would lead to bugs that were hard
   to test for.
 

--- a/docs/convenience.rst
+++ b/docs/convenience.rst
@@ -23,7 +23,7 @@ We can use it with a manager:
 
     >>> with transaction.manager as t:
     ...     dm['z'] = 3
-    ...     t.note('test 3')
+    ...     t.note(u'test 3')
 
     >>> dm['z']
     3

--- a/transaction/_manager.py
+++ b/transaction/_manager.py
@@ -25,6 +25,7 @@ from transaction.interfaces import ITransactionManager
 from transaction.interfaces import TransientError
 from transaction.weakset import WeakSet
 from transaction._compat import reraise
+from transaction._compat import text_type
 from transaction._transaction import Transaction
 
 
@@ -174,13 +175,15 @@ class TransactionManager(object):
         doc = func.__doc__
         if name != '_':
             if doc:
-                doc = name + '\n\n' + doc
+                doc = name + u'\n\n' + doc
             else:
                 doc = name
 
         for i in range(1, tries + 1):
             txn = self.begin()
             if doc:
+                if not isinstance(doc, text_type):
+                    doc = doc.decode('ascii')
                 txn.note(doc)
 
             try:

--- a/transaction/_manager.py
+++ b/transaction/_manager.py
@@ -175,15 +175,16 @@ class TransactionManager(object):
         doc = func.__doc__
         if name != '_':
             if doc:
-                doc = name + u'\n\n' + doc
+                doc = name + '\n\n' + doc
             else:
                 doc = name
+
+        if doc and not isinstance(doc, text_type):
+            doc = doc.decode('utf-8')
 
         for i in range(1, tries + 1):
             txn = self.begin()
             if doc:
-                if not isinstance(doc, text_type):
-                    doc = doc.decode('ascii')
                 txn.note(doc)
 
             try:

--- a/transaction/_transaction.py
+++ b/transaction/_transaction.py
@@ -27,6 +27,7 @@ from transaction._compat import get_thread_ident
 from transaction._compat import native_
 from transaction._compat import bytes_
 from transaction._compat import StringIO
+from transaction._compat import text_type
 
 _marker = object()
 
@@ -134,7 +135,9 @@ class Transaction(object):
 
     @user.setter
     def user(self, v):
-        self._user = v + u'' # + u'' to make sure it's unicode
+        if not isinstance(v, text_type):
+            raise TypeError("User must be text (unicodd)")
+        self._user = v
 
     @property
     def description(self):
@@ -142,7 +145,9 @@ class Transaction(object):
 
     @description.setter
     def description(self, v):
-        self._description = v + u'' # + u'' to make sure it's unicode
+        if not isinstance(v, text_type):
+            raise TypeError("Description must be text (unicodd)")
+        self._description = v
 
     def isDoomed(self):
         """ See ITransaction.
@@ -528,15 +533,22 @@ class Transaction(object):
     def note(self, text):
         """ See ITransaction.
         """
+        if not isinstance(text, text_type):
+            raise TypeError("Note must be text (unicodd)")
+
         text = text.strip()
         if self.description:
             self.description += u"\n" + text
         else:
             self.description = text
 
-    def setUser(self, user_name, path="/"):
+    def setUser(self, user_name, path=u"/"):
         """ See ITransaction.
         """
+        if not isinstance(user_name, text_type):
+            raise TypeError("User name must be text (unicodd)")
+        if not isinstance(path, text_type):
+            raise TypeError("User name must be text (unicodd)")
         self.user = u"%s %s" % (path, user_name)
 
     def setExtendedInfo(self, name, value):

--- a/transaction/_transaction.py
+++ b/transaction/_transaction.py
@@ -548,7 +548,7 @@ class Transaction(object):
         if not isinstance(user_name, text_type):
             raise TypeError("User name must be text (unicode)")
         if not isinstance(path, text_type):
-            raise TypeError("User name must be text (unicode)")
+            raise TypeError("Path must be text (unicode)")
         self.user = u"%s %s" % (path, user_name)
 
     def setExtendedInfo(self, name, value):

--- a/transaction/_transaction.py
+++ b/transaction/_transaction.py
@@ -136,7 +136,7 @@ class Transaction(object):
     @user.setter
     def user(self, v):
         if not isinstance(v, text_type):
-            raise TypeError("User must be text (unicodd)")
+            raise TypeError("User must be text (unicode)")
         self._user = v
 
     @property
@@ -146,7 +146,7 @@ class Transaction(object):
     @description.setter
     def description(self, v):
         if not isinstance(v, text_type):
-            raise TypeError("Description must be text (unicodd)")
+            raise TypeError("Description must be text (unicode)")
         self._description = v
 
     def isDoomed(self):
@@ -534,7 +534,7 @@ class Transaction(object):
         """ See ITransaction.
         """
         if not isinstance(text, text_type):
-            raise TypeError("Note must be text (unicodd)")
+            raise TypeError("Note must be text (unicode)")
 
         text = text.strip()
         if self.description:
@@ -546,9 +546,9 @@ class Transaction(object):
         """ See ITransaction.
         """
         if not isinstance(user_name, text_type):
-            raise TypeError("User name must be text (unicodd)")
+            raise TypeError("User name must be text (unicode)")
         if not isinstance(path, text_type):
-            raise TypeError("User name must be text (unicodd)")
+            raise TypeError("User name must be text (unicode)")
         self.user = u"%s %s" % (path, user_name)
 
     def setExtendedInfo(self, name, value):

--- a/transaction/tests/test__transaction.py
+++ b/transaction/tests/test__transaction.py
@@ -983,32 +983,38 @@ class TransactionTests(unittest.TestCase):
     def test_note(self):
         txn = self._makeOne()
         try:
-            txn.note('This is a note.')
+            txn.note(u'This is a note.')
             self.assertEqual(txn.description, u'This is a note.')
-            txn.note('Another.')
+            txn.note(u'Another.')
             self.assertEqual(txn.description, u'This is a note.\nAnother.')
         finally:
             txn.abort()
 
-    def test_description_nonascii_bytes(self):
+    def test_description_bytes(self):
         txn = self._makeOne()
         with self.assertRaises((UnicodeDecodeError, TypeError)):
-            txn.description = b'\xc2\x80'
+            txn.description = b'haha'
 
     def test_setUser_default_path(self):
         txn = self._makeOne()
-        txn.setUser('phreddy')
+        txn.setUser(u'phreddy')
         self.assertEqual(txn.user, u'/ phreddy')
 
     def test_setUser_explicit_path(self):
         txn = self._makeOne()
-        txn.setUser('phreddy', '/bedrock')
+        txn.setUser(u'phreddy', u'/bedrock')
         self.assertEqual(txn.user, u'/bedrock phreddy')
 
-    def test_user_nonascii_bytes(self):
+    def test_user_bytes(self):
         txn = self._makeOne()
         with self.assertRaises((UnicodeDecodeError, TypeError)):
-            txn.user = b'\xc2\x80'
+            txn.user = b'phreddy'
+        with self.assertRaises((UnicodeDecodeError, TypeError)):
+            txn.setUser(b'phreddy', u'/bedrock')
+        with self.assertRaises((UnicodeDecodeError, TypeError)):
+            txn.setUser(u'phreddy', b'/bedrock')
+        with self.assertRaises((UnicodeDecodeError, TypeError)):
+            txn.setUser(b'phreddy')
 
     def test_setExtendedInfo_single(self):
         txn = self._makeOne()

--- a/transaction/tests/test__transaction.py
+++ b/transaction/tests/test__transaction.py
@@ -992,7 +992,7 @@ class TransactionTests(unittest.TestCase):
 
     def test_description_bytes(self):
         txn = self._makeOne()
-        with self.assertRaises((UnicodeDecodeError, TypeError)):
+        with self.assertRaises(TypeError):
             txn.description = b'haha'
 
     def test_setUser_default_path(self):
@@ -1007,13 +1007,13 @@ class TransactionTests(unittest.TestCase):
 
     def test_user_bytes(self):
         txn = self._makeOne()
-        with self.assertRaises((UnicodeDecodeError, TypeError)):
+        with self.assertRaises(TypeError):
             txn.user = b'phreddy'
-        with self.assertRaises((UnicodeDecodeError, TypeError)):
+        with self.assertRaises(TypeError):
             txn.setUser(b'phreddy', u'/bedrock')
-        with self.assertRaises((UnicodeDecodeError, TypeError)):
+        with self.assertRaises(TypeError):
             txn.setUser(u'phreddy', b'/bedrock')
-        with self.assertRaises((UnicodeDecodeError, TypeError)):
+        with self.assertRaises(TypeError):
             txn.setUser(b'phreddy')
 
     def test_setExtendedInfo_single(self):


### PR DESCRIPTION
Insist that transaction user and description are text (unicode)

See: https://groups.google.com/forum/#!topic/zodb/U0H1kTh_dY4

There will be much breakage because of this for Python 2.7 applications. I had to fix quite a few ZODB tests, although that may not be a great indicator.