### PR TITLE
expose ITransaction.isRetryableError

### DIFF
--- a/transaction/_manager.py
+++ b/transaction/_manager.py
@@ -167,6 +167,7 @@ class TransactionManager(object):
             should_retry = getattr(dm, 'should_retry', None)
             if (should_retry is not None) and should_retry(error):
                 return True
+        return False
 
     run_no_func_types = int, type(None)
     def run(self, func=None, tries=3):

--- a/transaction/_transaction.py
+++ b/transaction/_transaction.py
@@ -550,6 +550,9 @@ class Transaction(object):
         """
         self.extension[name] = value
 
+    def isRetryableError(self, error):
+        return self._manager._retryable(type(error), error)
+
 
 # TODO: We need a better name for the adapters.
 

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -127,7 +127,7 @@ class ITransactionManager(Interface):
     def registeredSynchs():
         """Determine if any ISynchronizers are registered.
 
-        Return true is any are registered, and return False otherwise.
+        Return true if any are registered, and return False otherwise.
 
         This exists to support test cleanup/initialization
         """
@@ -331,6 +331,15 @@ class ITransaction(Interface):
         """Retrieve data held on behalf of an object.
 
         See set_data.
+        """
+
+    def isRetryableError(error):
+        """Determine if the error is retryable.
+
+        Return true if any joined IRetryDataManager considers the error
+        transient. Such errors may occur due to concurrency issues in the
+        underlying storage engine.
+
         """
 
 class ITransactionDeprecated(Interface):


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/transaction/issues/37.

Some discussion is here: https://groups.google.com/d/msg/python-transaction/7-965JdlBy0/OX8BPFDTBgAJ

I'm not sure what the right approach is to add a new method to `ITransaction` but I think it's the right place for this feature. Surely there is a way as everything in the library has an interface, so there must be a way to change them or we can never add features. :-)