### PR TITLE
add ITransactionManager.isActive api

### DIFF
--- a/transaction/_manager.py
+++ b/transaction/_manager.py
@@ -63,6 +63,9 @@ class TransactionManager(object):
         self._txn = None
         self._synchs = WeakSet()
 
+    def isActive(self):
+        return self._txn is not None
+
     def begin(self):
         """ See ITransactionManager.
         """

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -21,6 +21,10 @@ class ITransactionManager(Interface):
     Applications use transaction managers to establish transaction boundaries.
     """
 
+    def isActive():
+        """Return true if there is an active transaction.
+        """
+
     def begin():
         """Begin a new transaction.
 

--- a/transaction/tests/test__manager.py
+++ b/transaction/tests/test__manager.py
@@ -36,6 +36,15 @@ class TransactionManagerTests(unittest.TestCase):
         self.assertTrue(tm._txn is None)
         self.assertEqual(len(tm._synchs), 0)
 
+    def test_isActive_wo_existing_txn(self):
+        tm = self._makeOne()
+        self.assertFalse(tm.isActive())
+
+    def test_isActive_w_existing_txn(self):
+        tm = self._makeOne()
+        tm.begin()
+        self.assertTrue(tm.isActive())
+
     def test_begin_wo_existing_txn_wo_synchs(self):
         from transaction._transaction import Transaction
         tm = self._makeOne()


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/transaction/issues/35 by exposing a way to test if a transaction is active. Currently it's not possible without using private apis.