### PR TITLE
Add test for 'txn.user = None'.

### DIFF
--- a/transaction/_transaction.py
+++ b/transaction/_transaction.py
@@ -136,10 +136,9 @@ class Transaction(object):
 
     @user.setter
     def user(self, v):
-        if v is not None:
-            self._user = text_or_warn(v)
-        else:
-            self._user = u""
+        if v is None:
+            raise ValueError("user must not be None")
+        self._user = text_or_warn(v)
 
     @property
     def description(self):

--- a/transaction/_transaction.py
+++ b/transaction/_transaction.py
@@ -138,6 +138,8 @@ class Transaction(object):
     def user(self, v):
         if v is not None:
             self._user = text_or_warn(v)
+        else:
+            self._user = u""
 
     @property
     def description(self):

--- a/transaction/tests/test__transaction.py
+++ b/transaction/tests/test__transaction.py
@@ -1065,7 +1065,7 @@ class TransactionTests(unittest.TestCase):
         txn.user = b'phreddy'
         with self.assertRaises(ValueError):
             txn.user = None  # resets to empty text
-        self.assertEqual(txn.user, b'phreddy')
+        self.assertEqual(txn.user, u'phreddy')
 
     def _test_user_non_text(self, user, path, expect, both=False):
         txn = self._makeOne()

--- a/transaction/tests/test__transaction.py
+++ b/transaction/tests/test__transaction.py
@@ -1060,6 +1060,12 @@ class TransactionTests(unittest.TestCase):
         txn.setUser(u'phreddy', u'/bedrock')
         self.assertEqual(txn.user, u'/bedrock phreddy')
 
+    def test_user_w_none(self):
+        txn = self._makeOne()
+        txn.user = b'phreddy'
+        txn.user = None  # resets to empty text
+        self.assertEqual(txn.user, u'')
+
     def _test_user_non_text(self, user, path, expect, both=False):
         txn = self._makeOne()
         with warnings.catch_warnings(record=True) as w:

--- a/transaction/tests/test__transaction.py
+++ b/transaction/tests/test__transaction.py
@@ -1063,8 +1063,9 @@ class TransactionTests(unittest.TestCase):
     def test_user_w_none(self):
         txn = self._makeOne()
         txn.user = b'phreddy'
-        txn.user = None  # resets to empty text
-        self.assertEqual(txn.user, u'')
+        with self.assertRaises(ValueError):
+            txn.user = None  # resets to empty text
+        self.assertEqual(txn.user, b'phreddy')
 
     def _test_user_non_text(self, user, path, expect, both=False):
         txn = self._makeOne()


### PR DESCRIPTION
Restores 100% coverage.

`tox -e coverage` was failing with:

```python
Name                          Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------
transaction.py                   14      0      0      0   100%
transaction/_compat.py           13      0      0      0   100%
transaction/_manager.py         134      0     62      0   100%
transaction/_transaction.py     407      0    126      1    99%   139->exit
transaction/interfaces.py         9      0      0      0   100%
transaction/weakset.py           22      0      4      0   100%
-------------------------------------------------------------------------
TOTAL                           599      0    192      1    99%
nose.plugins.cover: ERROR: TOTAL Coverage did not reach minimum required: 100%

```