### PR TITLE
Don't crash when printing tracebacks under IPython on Python 2

### DIFF
--- a/transaction/_compat.py
+++ b/transaction/_compat.py
@@ -36,7 +36,13 @@ else:
 if PY3: #pragma NO COVER
     from io import StringIO
 else:
-    from io import BytesIO as StringIO
+    from io import BytesIO
+    # Prevent crashes in IPython when writing tracebacks if a commit fails
+    # ref: https://github.com/ipython/ipython/issues/9126#issuecomment-174966638
+    class StringIO(BytesIO):
+        def write(self, s):
+            s = native_(s, encoding='utf-8')
+            super(StringIO, self).write(s)
 
 if PY3: #pragma NO COVER
     from collections import MutableMapping

--- a/transaction/tests/test__transaction.py
+++ b/transaction/tests/test__transaction.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 # Copyright (c) 2001, 2002, 2005 Zope Foundation and Contributors.
@@ -1648,6 +1649,18 @@ class MiscellaneousTests(unittest.TestCase):
 
         transaction.abort() # should do nothing
         self.assertEqual(list(dm.keys()), ['a'])
+
+    def test_gh5(self):
+        from transaction import _transaction
+        from transaction._compat import native_
+
+        buffer = _transaction._makeTracebackBuffer()
+
+        s = u'ąčę'
+        buffer.write(s)
+
+        buffer.seek(0)
+        self.assertEqual(buffer.read(), native_(s, 'utf-8'))
 
 class Resource(object):
     _b = _c = _v = _f = _a = _x = _after = False


### PR DESCRIPTION
IPython puts unicode into linecache, which crashes traceback printing while committing with: `TypeError: 'unicode' does not have the buffer interface`.

IPython no longer supports Python 2 for new releases so this won't be fixed there, but it's nice to be able to use IPython with `transaction`.

ref: https://github.com/ipython/ipython/issues/9126#issuecomment-174966638

Fixes #5.