### PR TITLE
Fix transaction manager run problems #58

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Add support for Python 3.8.
 
+- Fix transaction manager run problems
+  (`#58 <https://github.com/zopefoundation/transaction/issues/58>`_)
+
 
 2.4.0 (2018-10-23)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,14 @@
 
 - Add support for Python 3.8.
 
-- Fix transaction manager run problems
-  (`#58 <https://github.com/zopefoundation/transaction/issues/58>`_)
+- ``TransactionManager.run`` now commits/aborts the transaction
+  "active" after the execution of *func* (and no longer the initial
+  transaction which might already have been committed/aborted by *func*)
+  (`#58 <https://github.com/zopefoundation/transaction/issues/58>`_).
+
+  It aborts the transaction now for all exceptions raised by *func* - even
+  if it is only an instance of `BaseException` but not of `Exception`,
+  such as e.g. a ``SystemExit`` or ``KeyboardInterupt`` exception.
 
 
 2.4.0 (2018-10-23)

--- a/transaction/_manager.py
+++ b/transaction/_manager.py
@@ -187,7 +187,7 @@ class TransactionManager(object):
         name = text_(name) if name else u''
         doc = text_(doc) if doc else u''
 
-        if name != u'_':
+        if name and name != u'_':
             if doc:
                 doc = name + u'\n\n' + doc
             else:

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -132,6 +132,37 @@ class ITransactionManager(Interface):
         This exists to support test cleanup/initialization
         """
 
+    def attempts(number=3):
+        """Generate up to *number* (transactional) context managers.
+
+        Each of the generated context managers sets up
+        a new transaction, executes the with block and
+        commits or aborts the transaction depending on whether
+        the with block execution was successful or resulted in
+        an exception. If the with block execution resulted in
+        a `TransientError` and the maximal number of attempts
+        is not yet reached, then the exception is swallowed
+        and the next context manager is generated.
+        In all other cases, the generation stops and a possible
+        exception is propagated.
+        """
+
+    def run(func=None, tries=3):
+        """Call (parameter less) *func*; retry in case of `TransientError`.
+
+        The call is tried up to *tries* times.
+
+        The call is performed in a new transaction. After
+        the call, the transaction is committed (no exception) or
+        aborted (exception).
+
+        `run` supports the alternative signature `run(tries=3)`.
+        If *func* is not given or passed as `None`, then
+        the call to `run` returns a function taking *func*
+        as argument and then calling `run(func, tries)`.
+        """
+
+
 class ITransaction(Interface):
     """Object representing a running transaction.
 

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -137,8 +137,8 @@ class ITransactionManager(Interface):
 
         This method is typically used as follows:
 
-           for attempt in self.attempts():
-               with attemp:
+           for attempt in transaction_manager.attempts():
+               with attempt:
                    *with block*
 
         The `with attempt` starts a new transaction for the execution
@@ -154,7 +154,8 @@ class ITransactionManager(Interface):
         """
 
     def run(func=None, tries=3):
-        """Call (parameter less) *func*; retry in case of `TransientError`.
+        """Call (parameter less) *func* in its own transaction;
+        retry in case of some kind of `TransientError`.
 
         The call is tried up to *tries* times.
 

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -135,16 +135,22 @@ class ITransactionManager(Interface):
     def attempts(number=3):
         """Generate up to *number* (transactional) context managers.
 
-        Each of the generated context managers sets up
-        a new transaction, executes the with block and
-        commits or aborts the transaction depending on whether
-        the with block execution was successful or resulted in
-        an exception. If the with block execution resulted in
-        a `TransientError` and the maximal number of attempts
-        is not yet reached, then the exception is swallowed
-        and the next context manager is generated.
-        In all other cases, the generation stops and a possible
-        exception is propagated.
+        This method is typically used as follows:
+
+           for attempt in self.attempts():
+               with attemp:
+                   *with block*
+
+        The `with attempt` starts a new transaction for the execution
+        of the *with block*. If the execution succeeds,
+        the transaction is commited and the `for` loop
+        terminates. If the execution raised an exception,
+        then the transaction is aborted.
+        If the exception was some kind
+        of `TransientError` and the maximal number of attempts
+        is not yet reached, then a next iteration of the `for` loop
+        starts. In all other cases, the `for` loop terminates
+        with the exception.
         """
 
     def run(func=None, tries=3):

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -19,6 +19,11 @@ class ITransactionManager(Interface):
     """An object that manages a sequence of transactions.
 
     Applications use transaction managers to establish transaction boundaries.
+
+    A transaction manager supports the "context manager" protocol:
+    Its `__enter__` begins a new transaction; its `__exit__` commits
+    the current transaction if no exception has occured; otherwise,
+    it aborts it.
     """
 
     explicit = Attribute(
@@ -135,7 +140,7 @@ class ITransactionManager(Interface):
     def attempts(number=3):
         """Generate up to *number* (transactional) context managers.
 
-        This method is typically used as follows:
+        This method is typically used as follows::
 
            for attempt in transaction_manager.attempts():
                with attempt:
@@ -143,7 +148,7 @@ class ITransactionManager(Interface):
 
         The `with attempt` starts a new transaction for the execution
         of the *with block*. If the execution succeeds,
-        the transaction is commited and the `for` loop
+        the (then current) transaction is commited and the `for` loop
         terminates. If the execution raised an exception,
         then the transaction is aborted.
         If the exception was some kind
@@ -160,7 +165,7 @@ class ITransactionManager(Interface):
         The call is tried up to *tries* times.
 
         The call is performed in a new transaction. After
-        the call, the transaction is committed (no exception) or
+        the call, the (then current) transaction is committed (no exception) or
         aborted (exception).
 
         `run` supports the alternative signature `run(tries=3)`.

--- a/transaction/tests/test__manager.py
+++ b/transaction/tests/test__manager.py
@@ -703,12 +703,16 @@ class TransactionManagerTests(unittest.TestCase):
         stopped.set()
         runner.join(1)
 
+    # The lack of the method below caused a test failure in one run
+    #   -- maybe caused indirectly by the failure of another test
+    # Defining the methods below reduced the "test coverage". We
+    #   therefore remove them again
     # the preceeding test (maybe others as well) registers `self` as
     #   synchronizer; satisfy the `ISynchronizer` requirements
-    def newTransaction(self, transaction):
-        pass
+##    def newTransaction(self, transaction):
+##        pass
 
-    beforeCompletion = afterCompletion = newTransaction
+##    beforeCompletion = afterCompletion = newTransaction
 
 
 class TestThreadTransactionManager(unittest.TestCase):

--- a/transaction/tests/test__manager.py
+++ b/transaction/tests/test__manager.py
@@ -704,15 +704,17 @@ class TransactionManagerTests(unittest.TestCase):
         runner.join(1)
 
     # The lack of the method below caused a test failure in one run
-    #   -- maybe caused indirectly by the failure of another test
-    # Defining the methods below reduced the "test coverage". We
-    #   therefore remove them again
-    # the preceeding test (maybe others as well) registers `self` as
-    #   synchronizer; satisfy the `ISynchronizer` requirements
-##    def newTransaction(self, transaction):
-##        pass
-
-##    beforeCompletion = afterCompletion = newTransaction
+    #   -- caused indirectly by the failure of another test (this
+    #   indicates that the tests in this suite are not fully isolated).
+    #   However, defining the methods below reduced the "test coverage"
+    #   once the initial test failure has been fixed.
+    #   We therefore comment them out.
+    ##    # the preceeding test (maybe others as well) registers `self` as
+    ##    #   synchronizer; satisfy the `ISynchronizer` requirements
+    ##    def newTransaction(self, transaction):
+    ##        pass
+    ##
+    ##    beforeCompletion = afterCompletion = newTransaction
 
 
 class TestThreadTransactionManager(unittest.TestCase):

--- a/transaction/tests/test__manager.py
+++ b/transaction/tests/test__manager.py
@@ -703,6 +703,13 @@ class TransactionManagerTests(unittest.TestCase):
         stopped.set()
         runner.join(1)
 
+    # the preceeding test (maybe others as well) registers `self` as
+    #   synchronizer; satisfy the `ISynchronizer` requirements
+    def newTransaction(self, transaction):
+        pass
+
+    beforeCompletion = afterCompletion = newTransaction
+
 
 class TestThreadTransactionManager(unittest.TestCase):
 


### PR DESCRIPTION
This PR documents `attempts` and  `run` in `transaction.interfaces.ITransactionManager` and implements `run` in terms of `attempts` (which properly uses transaction manager methods for transaction control). This fixes #58 