### PR TITLE
Modernize Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,28 @@
 language: python
-sudo: false
+
+dist: xenial
+
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
+    - 3.7
+    - 3.8-dev
     - pypy
     - pypy3
-matrix:
-    include:
-        - python: "3.7"
-          dist: xenial
-          sudo: true
+
 install:
     - pip install zope.testrunner coverage coveralls
     - pip install -U -e .[test,docs]
+
 script:
     - coverage run -m zope.testrunner --test-path=. -v
     - coverage run -a -m sphinx.cmd.build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+
 notifications:
     email: false
+
 after_success:
     - coveralls
+
 cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
  Changes
 =========
 
-2.4.1 (unreleased)
+3.0.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Drop support for Python 3.4.
+
+- Add support for Python 3.8.
 
 
 2.4.0 (2018-10-23)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '2.4.1.dev0'
+version = '3.0.0.dev0'
 here = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -43,10 +43,10 @@ setup(name='transaction',
           "Programming Language :: Python :: 2",
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: Implementation :: CPython",
           "Programming Language :: Python :: Implementation :: PyPy",
           "Framework :: ZODB",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,pypy,py34,py35,py36,py37,pypy3,coverage,docs
+    py27,pypy,py35,py36,py37,py38,pypy3,coverage,docs
 
 [testenv]
 commands =


### PR DESCRIPTION
- drop support for Python 3.4
- add support for Python 3.7
- bump to new major version, as Python 3.4 is still supported by
Debian 8

modified:   .travis.yml
modified:   CHANGES.rst
modified:   setup.py
modified:   tox.ini