### PR TITLE
xenial is now the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-dist: xenial
-
 python:
     - 2.7
     - 3.5


### PR DESCRIPTION
See https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment