### PR TITLE
Transaction._free drops more references, and Transaction.abort() is a bit safer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,9 +21,17 @@
 - Support abort hooks (symmetrically to commit hooks)
   (`#77 <https://github.com/zopefoundation/transaction/issues/77>`_).
 
-- Hooks are now cleared after successfull ``commit`` and ``abort`` to avoid
-  potential cyclic references.
+- Make Transaction drop references to its hooks, manager,
+  synchronizers and data after a successful ``commit()`` and after
+  *any* ``abort()``. This helps avoid potential cyclic references. See
+  `issue 82 <https://github.com/zopefoundation/transaction/issues/82>`_.
 
+- Allow synchronizers to access ``Transaction.data()`` when their
+  ``afterCompletion`` method is called while aborting a transaction.
+
+- Make it safe to call ``Transaction.abort()`` more than once. The
+  second and subsequent calls are no-ops. Previously a
+  ``ValueError(Foreign transaction)`` would be raised.
 
 2.4.0 (2018-10-23)
 ==================

--- a/docs/hooks.rst
+++ b/docs/hooks.rst
@@ -377,11 +377,10 @@ after commit hooks are registered
 
 .. doctest::
 
-    >>> mgr = TransactionManager()
-    >>> do = DataObject(mgr)
-
     >>> t = begin()
-    >>> t._manager._txn is not None
+    >>> t._manager is not None
+    True
+    >>> t._manager._txn is t
     True
 
     >>> t.addAfterCommitHook(hook, ('-', 1))
@@ -390,7 +389,9 @@ after commit hooks are registered
     >>> log
     ["True arg '-' kw1 1 kw2 'no_kw2'"]
 
-    >>> t._manager._txn is not None
-    False
+    >>> t._manager is None
+    True
+    >>> mgr._txn is None
+    True
 
     >>> reset_log()


### PR DESCRIPTION
Specifically, free the manager and synchronizers, plus a few other dictionaries that could be arbitrary size and some of which could contain arbitrary data.

And `abort()` always invokes `_free()` even in the case of exceptions. `commit()` still doesn't so that the synchronizers are available for the expected abort().

But take care about when and how abort frees its manager: not only does this preserve backwards compatibility, but it lets it be safe to abort a transaction object more than once. A happy side-effect of only freeing the manager there is that synchronizers can access
data they set in `afterCompletion()`.

Previously, this code would raise `ValueError`; it now does nothing on the second call to `abort`:
```python
tx = transaction.get()
tx.abort()
transaction.get()
tx.abort()
```

If a synchronizer raised an exception in `beforeCompletion`, you'd be left with a transaction manager in a bad state and a difficult to clean up situation. Previously, the transaction would never be freed, so this final assertion held and resources joined to the transaction would not actually be aborted:
```python
import transaction

class Sync(object):
    def beforeCompletion(self, txn):
        raise Exception("Bad sync")

sync = Sync()

transaction.manager.registerSynch(sync)
tx = transaction.get()
try:
    transaction.abort()
except Exception:
    pass
assert tx is transaction.get()
```

Now the resources are properly aborted and the transaction manager can start a new transaction (assuming the bad synchronizer can be fixed, of course).

From discussion in #82