### PR TITLE
Publish the docs for the two explicit-mode exceptions added in 2.1.0.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,6 +58,9 @@ Interfaces
    :members:
    :member-order: bysource
 
+.. autoclass:: NoTransaction
+.. autoclass:: AlreadyInTransaction
+
 API Objects
 -----------
 

--- a/docs/datamanager.rst
+++ b/docs/datamanager.rst
@@ -142,7 +142,7 @@ If there was a preceeding savepoint, the transaction must match:
    >>> rollback = dm.savepoint(t1)
    >>> dm.prepare(t2)
    Traceback (most recent call last):
-   ,,,
+   ...
    TypeError: ('Transaction missmatch', '2', '1')
 
    >>> dm.prepare(t1)

--- a/docs/resourcemanager.rst
+++ b/docs/resourcemanager.rst
@@ -127,7 +127,7 @@ If there was a preceeding savepoint, the transaction must match:
    >>> rollback = rm.savepoint(t1)
    >>> rm.tpc_begin(t2)
    Traceback (most recent call last):
-   ,,,
+   ...
    TypeError: ('Transaction missmatch', '2', '1')
 
    >>> rm.tpc_begin(t1)

--- a/transaction/interfaces.py
+++ b/transaction/interfaces.py
@@ -33,6 +33,8 @@ class ITransactionManager(Interface):
         In explicit mode, transactions must be begun explicitly, by
         calling ``begin()`` and ended explicitly by calling
         ``commit()`` or ``abort()``.
+
+        .. versionadded:: 2.1.0
         """)
 
 
@@ -402,7 +404,7 @@ class ITransaction(Interface):
         positional arguments to be passed, defaulting to an empty tuple
         `kws` is a dictionary of keyword argument names and values to be
         passed, or the default None (no keyword arguments are passed).
-        
+
         Multiple hooks can be registered and will be called in the order they
         were registered (first registered, first called).  This method can
         also be called from a hook:  an executing hook can register more
@@ -690,6 +692,8 @@ class NoTransaction(TransactionError):
     affects an exciting transaction, but no transaction was begun.
     The transaction manager was in explicit mode, so a new transaction
     was not explicitly created.
+
+    .. versionadded:: 2.1.0
     """
 
 class AlreadyInTransaction(TransactionError):
@@ -698,4 +702,6 @@ class AlreadyInTransaction(TransactionError):
     An application called ``begin()`` on a transaction manager in
     explicit mode, without committing or aborting the previous
     transaction.
+
+    .. versionadded:: 2.1.0
     """


### PR DESCRIPTION
Also fix the lexing and highlighting of two doctest blocks.