### PR TITLE
Make before commit hooks raise exceptions again, broken in 2.4.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 3.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Exception raised by a before commit hook is no longer hidden.  No
+  further commit hooks are called and exception is propagated to
+  the caller of ``commit()``. See
+  `#95 <https://github.com/zopefoundation/transaction/pull/95>`_.
 
 
 3.0.0 (2019-12-11)

--- a/src/transaction/_transaction.py
+++ b/src/transaction/_transaction.py
@@ -378,18 +378,17 @@ class Transaction(object):
                                    hook, exc_info=sys.exc_info())
         finally:
             del hooks[:]  # clear hooks
-            if not clean:
-                return
-            # The primary operation has already been performed.
-            # But the hooks execution might have left the resources
-            # in an unclean state. Clean up
-            for rm in self._resources:
-                try:
-                    rm.abort(self)
-                except:  # noqa: E722 do not use bare 'except'
-                    # XXX should we take further actions here ?
-                    self.log.error("Error in abort() on manager %s",
-                                   rm, exc_info=sys.exc_info())
+            if clean:
+                # The primary operation has already been performed.
+                # But the hooks execution might have left the resources
+                # in an unclean state. Clean up
+                for rm in self._resources:
+                    try:
+                        rm.abort(self)
+                    except:  # noqa: E722 do not use bare 'except'
+                        # XXX should we take further actions here ?
+                        self.log.error("Error in abort() on manager %s",
+                                       rm, exc_info=sys.exc_info())
 
     def getBeforeAbortHooks(self):
         """See `~transaction.interfaces.ITransaction`."""


### PR DESCRIPTION
Before commit hooks do not ask for cleaning and are expected to raise the exception.

Refactoring in 5aef8c2a accidentally introduced a return in a `finally:` block.  Because a return in finally block takes priority over raised exception, if one hook failed, remaining hooks were simply not executed, no error was logged, and we proceeded with committing the transaction anyway.

