### PR TITLE
Use dist: focal on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: xenial
+dist: focal
 
 python:
     - 2.7
@@ -8,7 +8,7 @@ python:
     - 3.6
     - 3.7
     - 3.8
-    - pypy
+    - pypy2
     - pypy3
 
 install:


### PR DESCRIPTION
The xenial build of pypy on Travis CI links against OpenSSL 1.0.2, which
causes pip install cryptography to fail with

    RuntimeError: You are linking against OpenSSL 1.0.2, which is no longer
    supported by the OpenSSL project. To use this version of cryptography
    you need to upgrade to a newer version of OpenSSL. For this version only
    you can also set the environment variable CRYPTOGRAPHY_ALLOW_OPENSSL_102
    to allow OpenSSL 1.0.2.

Note that 'pypy' is not a valid Python version when using dist: bionic
or dist: focal and you have to use 'pypy2' instead.