### PR TITLE
Fix generating documentation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     strategy:
-      # We want do see all failures:
+      # We want to see all failures:
       fail-fast: false
       matrix:
         config:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     strategy:
+      # We want do see all failures:
+      fail-fast: false
       matrix:
         config:
         # [Python version, tox env]

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "5938e71a0184bc411a10bacc83f4f627ea6d4844"
+commit-id = "f8468b0bc5c92479b3043372d89cf5852176015d"
 
 [python]
 with-appveyor = false

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "f8468b0bc5c92479b3043372d89cf5852176015d"
+commit-id = "517293cf7fbff6d056b7fe699777e5336361dcbf"
 
 [python]
 with-appveyor = false

--- a/tox.ini
+++ b/tox.ini
@@ -21,10 +21,8 @@ deps =
     zope.testrunner
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
-    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 extras =
     test
-    docs
 
 [testenv:lint]
 basepython = python3
@@ -41,7 +39,10 @@ commands =
 [testenv:docs]
 basepython = python3
 skip_install = false
-deps =
+# Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
+deps = Sphinx < 4
+extras =
+    docs
 commands_pre =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,14 @@ envlist =
 usedevelop = true
 deps =
     zope.testrunner
+    # Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
+    Sphinx < 4
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
+    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 extras =
     test
+    docs
 
 [testenv:lint]
 basepython = python3
@@ -41,8 +45,6 @@ basepython = python3
 skip_install = false
 # Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
 deps = Sphinx < 4
-extras =
-    docs
 commands_pre =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
@@ -55,6 +57,8 @@ allowlist_externals =
 deps =
     coverage
     coverage-python-version
+    # Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
+    Sphinx < 4
     zope.testrunner
 commands =
     mkdir -p {toxinidir}/parts/htmlcov


### PR DESCRIPTION
Use `Sphinx < 4` to prevent problems with `repoze.sphinx.autointerface`.