### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/transaction/tests/test__manager.py
+++ b/src/transaction/tests/test__manager.py
@@ -708,7 +708,7 @@ class TransactionManagerTests(unittest.TestCase):
             def __init__(self):
                 threading.Thread.__init__(self)
                 self.manager = transaction.manager.manager
-                self.setDaemon(True)
+                self.daemon = True
                 self.start()
 
             def run(self):


### PR DESCRIPTION
Testing with Python 3.11 via `tox -e py311` we get two deprecation warnings:

```
...
/private/tmp/transaction/src/transaction/tests/test_weakset.py:140: DeprecationWarning: unittest.makeSuite() is deprecated and will be removed in Python 3.13. Please use unittest.TestLoader.loadTestsFromTestCase() instead.
  return unittest.makeSuite(WeakSetTests)
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
/private/tmp/transaction/src/transaction/tests/test__manager.py:711: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
  self.setDaemon(True)
...
```

https://github.com/zopefoundation/transaction/actions/runs/5037515550/jobs/9034409507#step:6:25

Let's fix them.

Also Python 3.12 is now in beta and it's time to start testing it:

> We **strongly encourage** maintainers of third-party Python projects to test with 3.12 during the beta phase and report issues found to the Python bug tracker as soon as possible.

https://discuss.python.org/t/python-3-12-beta-1-and-feature-freeze-is-here/26982
